### PR TITLE
Derive Debug for Batcher and Autobatcher

### DIFF
--- a/src/auto_batcher.rs
+++ b/src/auto_batcher.rs
@@ -44,7 +44,7 @@ use crate::{
 ///
 /// If this delay is a concern, it is recommended that you periodically flush
 /// the batcher on your own by calling [Self::flush].
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct AutoBatcher {
     client: HttpClient,
     batcher: Batcher,

--- a/src/batcher.rs
+++ b/src/batcher.rs
@@ -55,7 +55,7 @@ const MAX_BATCH_SIZE: usize = 1024 * 512;
 /// added to your message.
 /// You can disable this behaviour with the [without_auto_timestamp] method
 /// though.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Batcher {
     pub(crate) buf: Vec<BatchMessage>,
     pub(crate) byte_count: usize,

--- a/src/http.rs
+++ b/src/http.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 ///
 /// `HttpClient` implements [`Client`](../client/trait.Client.html); see the
 /// documentation for `Client` for more on how to send events to Segment.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct HttpClient {
     client: reqwest::Client,
     host: String,


### PR DESCRIPTION
# Pull Request

## What does this PR do?
- It's useful to derive Debug for public types. In particular this is useful for me because I'm using [OnceCell::set](https://docs.rs/once_cell/latest/once_cell/sync/struct.OnceCell.html#method.set) (which returns a `Result` with an `Autobatcher` as the error type) in combination with `Result::unwrap`, which requires the error type to be `Debug`.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
