### PR TITLE
fix MAX_BATCH_SIZE const

### DIFF
--- a/src/batcher.rs
+++ b/src/batcher.rs
@@ -6,7 +6,7 @@ use serde_json::{Map, Value};
 use time::OffsetDateTime;
 
 const MAX_MESSAGE_SIZE: usize = 1024 * 32;
-const MAX_BATCH_SIZE: usize = 1024 * 512;
+const MAX_BATCH_SIZE: usize = 1024 * 500;
 
 /// A batcher can accept messages into an internal buffer, and report when
 /// messages must be flushed.


### PR DESCRIPTION
# Pull Request

## Solved issue
Wrong limit of MAX_BATCH_SIZE causes 400 error on sending data when the batch is fully loaded.
`HTTP status client error (400 Bad Request) for url (https://api.segment.io/v1/batch)`

## What does this PR do?
Replaced MAX_BATCH_SIZE value from 512 to 500 according the docs limit of 500 KB.
https://segment.com/docs/connections/sources/catalog/libraries/server/http-api/
